### PR TITLE
Add update.py script to manually update DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ epschedule-*.json
 epschedule-v2-*.json
 service_account.json
 service_account*.json
+
+# Misc
+.DS_Store

--- a/Justfile
+++ b/Justfile
@@ -36,9 +36,11 @@ run *FLAGS:
 deploy:     
     gcloud app deploy --project=epschedule-v2 
 
-crawl-schedules *FLAGS:
-    cd cron; python schedules.py {{FLAGS}}
+update-schedules *FLAGS:
+    python update.py {{FLAGS}} schedules
 
-crawl-photos *FLAGS:
-    cd cron; python photos.py {{FLAGS}}
+update-photos *FLAGS:
+    python update.py {{FLAGS}} photos
 
+update-lunches *FLAGS:
+    python update.py {{FLAGS}} lunches

--- a/cron/four11.py
+++ b/cron/four11.py
@@ -1,0 +1,66 @@
+import dataclasses
+import json
+from typing import List, Optional
+
+import requests
+from google.cloud import secretmanager
+
+PEOPLE_ENDPOINT_URL = "https://four11.eastsideprep.org/epschedule/people"
+COURSE_ENDPOINT_URL = "https://four11.eastsideprep.org/epsnet/courses/{}"
+SECRET_REQUEST = {"name": "projects/epschedule-v2/secrets/four11_key/versions/1"}
+
+
+@dataclasses.dataclass
+class Four11User:
+    id: int
+    firstname: str
+    preferred_name: str
+    lastname: str
+    lunch_id: int
+    email: str
+    gradyear: str
+    photo_url: str
+
+    def username(self):
+        return self.email.split("@")[0]
+
+    def display_name(self):
+        return f"{self.preferred_name or self.firstname} {self.lastname}"
+
+    def is_student(self):
+        return not self.is_staff(self.id)
+
+    def is_staff(self):
+        return self.gradyear != "fac/staff"
+
+    def class_of(self) -> Optional[int]:
+        return int(self.gradyear) if self.is_student() else None
+
+
+class Four11Client:
+    def __init__(self):
+        self._session = requests.Session()
+        secret_client = secretmanager.SecretManagerServiceClient()
+        secret_response = secret_client.access_secret_version(request=SECRET_REQUEST)
+        self._api_key = secret_response.payload.data.decode("UTF-8")
+
+    def _auth_header(self):
+        return {"Authorization": "Bearer {}".format(self._api_key)}
+
+    def api_key(self) -> str:
+        return self._api_key
+
+    def get_courses(self, username: str, term_id: int):
+        response = self._session.get(
+            COURSE_ENDPOINT_URL.format(username),
+            headers=self._auth_header(),
+            params={"term_id": str(term_id)},
+        )
+        response.raise_for_status()
+        return json.loads(response.content)
+
+    def get_people(self) -> List[Four11User]:
+        response = self._session.get(PEOPLE_ENDPOINT_URL, headers=self._auth_header())
+        response.raise_for_status()
+        objs = json.loads(response.content)
+        return [Four11User(**obj) for obj in objs]

--- a/cron/test_lunch.py
+++ b/cron/test_lunch.py
@@ -8,7 +8,7 @@ from cron.update_lunch import add_events
 def test_read_lunches():
     events = []
     with patch(
-        "cron.update_lunch.write_event_to_db", side_effect=lambda e: events.append(e)
+        "cron.update_lunch.write_event_to_db", side_effect=lambda c, e: events.append(e)
     ) as mock:
         ICS_PATH = "data/test_lunch.ics"
         # Reads the ICS file to get a lunch object for 10/7/2019, Cheese Manicotti

--- a/cron/test_lunch.py
+++ b/cron/test_lunch.py
@@ -6,15 +6,14 @@ from cron.update_lunch import add_events
 
 # Test reading lunch data from an ICS file and sanitizing it.
 def test_read_lunches():
-    events = []
-    with patch(
-        "cron.update_lunch.write_event_to_db", side_effect=lambda c, e: events.append(e)
-    ) as mock:
+    patch("google.cloud.ndb.Client")
+    with patch("cron.update_lunch.write_event_to_db") as mock:
         ICS_PATH = "data/test_lunch.ics"
         # Reads the ICS file to get a lunch object for 10/7/2019, Cheese Manicotti
         fake_response = open(ICS_PATH).read()
         add_events(fake_response)
-        assert len(events) == 1
-        event = events[0]
+
+        assert mock.call_count == 1  # summary() == "Cheese Manicotti"
+        event = mock.call_args[0][1]
         assert event.summary == "Monday | Cheese Manicotti"
         assert event.day == datetime.date(2019, 10, 7)

--- a/cron/test_lunch.py
+++ b/cron/test_lunch.py
@@ -6,7 +6,6 @@ from cron.update_lunch import add_events
 
 # Test reading lunch data from an ICS file and sanitizing it.
 def test_read_lunches():
-    patch("google.cloud.ndb.Client")
     with patch("cron.update_lunch.write_event_to_db") as mock:
         ICS_PATH = "data/test_lunch.ics"
         # Reads the ICS file to get a lunch object for 10/7/2019, Cheese Manicotti

--- a/cron/update_lunch.py
+++ b/cron/update_lunch.py
@@ -1,8 +1,12 @@
 import datetime
 import logging
+import os
 
 import requests
 from google.cloud import ndb
+
+# TODO(juberti): Fully mock out NDB so we don't need to talk to GCP when running tests.
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "service_account.json"
 
 # Globals
 TIME_FORMAT = "%Y%m%dT%H%M%S"

--- a/update.py
+++ b/update.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+
+from cron import photos, schedules, update_lunch
+
+if __name__ == "__main__":
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "service_account.json"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("data", help="Which data update.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="If set, the results are not uploaded to production.",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print debugging output."
+    )
+    args = parser.parse_args()
+
+    callable = None
+    if args.data == "lunches":
+        callable = update_lunch.read_lunches
+    elif args.data == "photos":
+        callable = photos.crawl_photos
+    elif args.data == "schedules":
+        callable = schedules.crawl_schedules
+    else:
+        print("Invalid data type.")
+        exit(1)
+
+    callable(args.dry_run, args.verbose)


### PR DESCRIPTION
Fixes #506.
To update schedules manually, we now do 
`python update.py schedules` rather than running `cron/update_schedules.py` directly.
Also adds four11.py with a set of utilities to make it easier to deal with info from Four11.