### PR TITLE
Add tests for Four11 code (used in cron)

### DIFF
--- a/cron/four11.py
+++ b/cron/four11.py
@@ -14,12 +14,12 @@ SECRET_REQUEST = {"name": "projects/epschedule-v2/secrets/four11_key/versions/1"
 class Four11User:
     id: int
     firstname: str
-    preferred_name: str
     lastname: str
     lunch_id: int
     email: str
     gradyear: str
     photo_url: str
+    preferred_name: Optional[str] = None
 
     def username(self):
         return self.email.split("@")[0]

--- a/cron/test_four11.py
+++ b/cron/test_four11.py
@@ -1,0 +1,34 @@
+from cron import four11
+
+
+def test_four11_user():
+    student = four11.Four11User(
+        id=1,
+        firstname="John",
+        preferred_name="Johnny",
+        lastname="Doe",
+        lunch_id=2,
+        email="jdoe@eastsideprep.org",
+        gradyear="2021",
+        photo_url="https://four11.eastsideprep.org/epschedule/photos/1",
+    )
+    assert student.username() == "jdoe"
+    assert student.display_name() == "Johnny Doe"
+    assert student.is_student()
+    assert not student.is_staff()
+    assert student.class_of() == 2021
+
+    teacher = four11.Four11User(
+        id=2,
+        firstname="Jane",
+        lastname="Smith",
+        lunch_id=3,
+        email="jsmith@eastsideprep.org",
+        gradyear="fac/staff",
+        photo_url="https://four11.eastsideprep.org/epschedule/photos/2",
+    )
+    assert teacher.username() == "jsmith"
+    assert teacher.display_name() == "Jane Smith"
+    assert not teacher.is_student()
+    assert teacher.is_staff()
+    assert teacher.class_of() is None


### PR DESCRIPTION
These tests would have caught the bug that @auberti ran into where all student photos were black and white because of an issue in the `is_staff` method.