### PR TITLE
show shared free periods as shared

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -693,7 +693,7 @@ function isSharedClass(scheduleObj, termid) {
     if (
       userClasses[i].period == scheduleObj.period &&
       userClasses[i].name == scheduleObj.name &&
-      userClasses[i].teacher_username == scheduleObj.teacherUsername
+      (userClasses[i].teacher_username != null ? userClasses[i].teacher_username : "")  == scheduleObj.teacherUsername
     ) {
       return true;
     }


### PR DESCRIPTION
This properly shows shared free periods.

(they don't show up now because userClasses uses null for the teacher username but scheduleObj uses an empty string, which are not equal)