### PR TITLE
Join Hack Club button fix

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -8,6 +8,12 @@
   }
 }
 
+@media (max-width: 576px){
+  .join-button {
+    display: none;
+  }
+}
+
 @media (prefers-color-scheme:dark)
 {
   :root{

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,7 +111,7 @@
               <paper-icon-button class="" icon="menu" paper-drawer-toggle>
               </paper-icon-button>
               <span class="title" id="day">Today</span>
-              <button style = "position:relative; left:-20px;" onclick="window.location.href = 'https://forms.microsoft.com/r/sEqxAVt4PB'" class="join-button">Join Hack Club/button>
+              <button style = "position:relative; left:-20px;" onclick="window.location.href = 'https://forms.microsoft.com/r/sEqxAVt4PB'" class="join-button">Join Hack Club</button>
               <!-- Draw our calendar icon on top of the native picker -->
               <span class="datepicker-toggle">
                 <span class="datepicker-toggle-button">


### PR DESCRIPTION
Button was overflowing and not appearing correctly due to missing `<`. Fixed this, and made the button invisible for mobile devices (as the UI for mobile devices gets covered by this button). The mobile fix is temporary, just to keep the website pleasing for users.