### PR TITLE
Simple runtime edit

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,1 +1,1 @@
-runtime: python37
+runtime: python312


### PR DESCRIPTION
The issue is that in past commits (#648 and #649), there were errors in being unable to deploy to the app engine. The errors appear to have been caused by deprecated support for Python 3.7, the version we currently use.

I changed it to 3.12 to avoid dealing with errors for a while (until probably 2029). Testing it locally works, although I don't know if it is reflected when testing locally. Also, I am not sure how to test this error without going for the commit

More information on deprecated runtimes is here: https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule