### PR TITLE
Prevent Future Test Failures

### DIFF
--- a/runbeforecommit.py
+++ b/runbeforecommit.py
@@ -1,3 +1,4 @@
+#Before committing, run this. Make sure you have black installed.
+#Command is "pip install black"
 import os
-
 os.system("python -m black .")

--- a/runbeforecommit.py
+++ b/runbeforecommit.py
@@ -1,0 +1,3 @@
+import os
+
+os.system("python -m black .")


### PR DESCRIPTION
Adds runbeforecommit.py to enforce black formatting. All contributors should run this before committing anything to ensure the tests pass.